### PR TITLE
Fix wrong config type detection

### DIFF
--- a/Core/ConfigImport.php
+++ b/Core/ConfigImport.php
@@ -293,15 +293,23 @@ class ConfigImport extends CommandBase
 
     protected function getTypeAndValue($sVarName, $mVarValue)
     {
+        $specialTypes = ['str', 'bool', 'arr', 'aarr', 'select', 'string', 'int', 'num'];
         if ($this->isAssocArray($mVarValue)) {
-            $iCount = count($mVarValue);
-            if ($iCount == 0) {
-                $sVarType = 'arr';
-            } elseif ($iCount > 1) {
-                $sVarType = 'aarr';
-            } else {
-                $sVarType = key($mVarValue);
-                $mVarValue = $mVarValue[$sVarType];
+            /*
+             * We need to cover multiple sort of values here, the easiest one is just an assoc-array
+             * which will be saved as a 'aarr'.
+             * But we also need to cover some special config types like these:
+             *    blPsBasketReservationEnabled:
+             *      str: '0'
+             *    blPsLoginEnabled:
+             *      str: '0'
+             * This looks like an assoc-array, but in reality it is just a boolean flag
+             * which must be saved with the type 'str' (WAT?)
+             */
+            $sVarType = 'aarr';
+            if (count($mVarValue) === 1 && in_array(array_keys($mVarValue)[0], $specialTypes, true)) {
+                $sVarType = array_keys($mVarValue)[0];
+                $mVarValue = array_values($mVarValue)[0];
             }
         } elseif (is_array($mVarValue)) {
             $sVarType = 'arr';


### PR DESCRIPTION
This is exactly the same as https://github.com/OXIDprojects/oxid_modules_config/pull/49

I guess we need to find a better way to split files needed for these two projects.

---
If you pass an assoc-array with exactly 1 value it is screwed up by that
check. We ended up with strange data like this in one of our projects:

```
MySQL [oxid]> SELECT * FROM `oxconfig` WHERE `OXVARNAME` = 'moduleSmartyPluginDirectories' \G
*************************** 1. row ***************************
                      OXID: 077f925565f97224aa60355d6d07553b
                  OXSHOPID: 1
                  OXMODULE:
                 OXVARNAME: moduleSmartyPluginDirectories
                 OXVARTYPE: ffwebcomponents
                OXVARVALUE:

               OXTIMESTAMP: 2020-10-15 14:57:15
```
Note that the OXVARTYPE is set to the module-id in our case, but it
should be `aarr`. The value in our yaml file looks like this:
```
moduleSmartyPluginDirectories:
    ffwebcomponents:
        - views/smarty
```
I tested it also with more than one module and I was able to confirm,
that this will work (since the count-check is only buggy for exactly one
array-item):
```
moduleSmartyPluginDirectories:
    ffwebcomponents:
        - views/smarty
    foo:
        - bar
```